### PR TITLE
Add JSDoc documentation to createRuntime.ts and types.ts

### DIFF
--- a/packages/core/src/test_resources/createRuntime.ts
+++ b/packages/core/src/test_resources/createRuntime.ts
@@ -16,8 +16,18 @@ import {
     zeroUuid,
 } from "./constants.ts";
 import { User } from "./types.ts";
-//test
 
+/**
+ * Creates a runtime environment based on the provided configuration.
+ * 
+ * @param {Object} options - The options object containing configuration properties.
+ * @param {Record<string, string> | NodeJS.ProcessEnv} [options.env] - Environment variables or Node.js process environment.
+ * @param {number} [options.conversationLength] - The length of the conversation.
+ * @param {Evaluator[]} [options.evaluators] - Array of evaluators.
+ * @param {Action[]} [options.actions] - Array of actions.
+ * @param {Provider[]} [options.providers] - Array of providers.
+ * @returns {Object} - An object containing the created user, session, and runtime.
+ */
 export async function createRuntime({
     env,
     conversationLength,

--- a/packages/core/src/test_resources/types.ts
+++ b/packages/core/src/test_resources/types.ts
@@ -1,7 +1,6 @@
 /**
- * Interface defining a User object.
- * @interface User
- * @property {string} id - The unique identifier of the user.
+ * Interface representing a user.
+ * @property {string} id - The unique identifier for the user.
  * @property {string} [email] - The email address of the user (optional).
  * @property {string} [phone] - The phone number of the user (optional).
  * @property {string} [role] - The role of the user (optional).


### PR DESCRIPTION
This pull request adds JSDoc documentation to /home/runner/work/eliza/eliza/packages/core/src/test_resources/createRuntime.ts and /home/runner/work/eliza/eliza/packages/core/src/test_resources/types.ts. These changes are related to PR #65 and are automatically generated. 

Changes:
- Added JSDoc documentation to functions and types in createRuntime.ts
- Added JSDoc documentation to types.ts

Reviewers, please ensure that the JSDoc comments accurately describe the functionality and parameters of the functions and types in the modified files. If any clarifications are needed, feel free to ask questions in the comments section. Thank you!